### PR TITLE
Remove Editor role since .leaf file cannot be open by this app

### DIFF
--- a/LeafSyntaxHighlighter/Info.plist
+++ b/LeafSyntaxHighlighter/Info.plist
@@ -12,9 +12,9 @@
 			<key>CFBundleTypeName</key>
 			<string>Leaf</string>
 			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
+			<string>None</string>
 			<key>LSHandlerRank</key>
-			<string>Default</string>
+			<string>None</string>
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>com.omrankhoja.leaf-source</string>
@@ -70,6 +70,10 @@
 				<key>public.filename-extension</key>
 				<array>
 					<string>leaf</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>text/html</string>
 				</array>
 			</dict>
 		</dict>


### PR DESCRIPTION
1. Remove Editor role since this app cannot read nor edit .leaf file
Set it to none make all other things working as expected﻿

Except the quicklook window will no longer recommend using this app to open it.
Instead it will use the default "text editor app"(since it is the default public.text editor app, I guess)
And if needed user can then set always open it using Xcode or VSCode

2. Add text/html mime-type